### PR TITLE
accessibilityLabel passed into title for renderTitleView

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,8 +201,9 @@ export default class ActionSheet extends Component {
                     key={'title'+i}
                     onPress={() => {this.hide(title);}}
                     style={[styles.item, this.state.textViewStyle, title.textViewStyle]}
+                    accessibilityLabel={title.accessibilityLabel}
                 >
-                    <Text style={[styles.defaultTextStyle, this.state.defaultTextStyle, titleStyle, title.textStyle]}>{title.title}</Text>
+                    <Text accessible={false} style={[styles.defaultTextStyle, this.state.defaultTextStyle, titleStyle, title.textStyle]}>{title.title}</Text>
                 </TouchableOpacity>
             );
             if (i != length - 1) {


### PR DESCRIPTION
I want to be able to specify additional accessibility text for **actionsheet** options. Currently the **actionsheet** only reads out the content. I have added an `accessibilityLabel` prop to allow additional accessibility text to be specified.